### PR TITLE
Replace $defout to $>

### DIFF
--- a/data/doc/xmpp4r/examples/basic/client.rb
+++ b/data/doc/xmpp4r/examples/basic/client.rb
@@ -19,7 +19,7 @@ class BasicClient
     # main loop
     while not quit do
       print "> "
-      $defout.flush
+      $>.flush
       line = gets
       quit = true if line.nil?
       if not quit


### PR DESCRIPTION
`$defout` has already disappeared from Ruby1.9 or higher
