### PR TITLE
Better control of history on muc.join

### DIFF
--- a/lib/xmpp4r/muc/helper/mucclient.rb
+++ b/lib/xmpp4r/muc/helper/mucclient.rb
@@ -85,10 +85,10 @@ module Jabber
         xmuc = XMUC.new
         xmuc.password = password
 
-        if !opts[:history]
-          history = REXML::Element.new( 'history').tap {|h| h.add_attribute('maxstanzas','0') }
-          xmuc.add_element history
-        end
+        # Add history/maxstanzas as requested. false=0
+        xmuc.add_element REXML::Element.new('history').tap { |hist|
+          hist.add_attribute 'maxstanzas', (opts[:history]||0).to_i.to_s
+        } unless opts[:history].nil?
 
         pres.add(xmuc)
 


### PR DESCRIPTION
MUCClient's `opts[:history]` now accepts false, or a fixnum to pass in the history/maxstanzas header to control the number of lines of history the server should send.

The current implementation uses a boolean to disable history. The maxstanza's attribute takes an number of history messages to send. This patch lets the client request a number of lines of history, instead of simply disabling it, while keeping backwards compatibility.
