### PR TITLE
Wrong inline documentation in `client.rb`

### DIFF
--- a/lib/xmpp4r/client.rb
+++ b/lib/xmpp4r/client.rb
@@ -38,7 +38,7 @@ module Jabber
     # be resolved. If none works, fallback is connecting to the domain part
     # of the jid.
     # host:: [String] Optional c2s host, will be extracted from jid if nil
-    # use_ssl:: [Boolean] Optional. Use (old, deprecated) SSL when connecting.
+    # port:: [Fixnum] The server port (default: 5222)
     # return:: self
     def connect(host = nil, port = 5222)
       if host.nil?


### PR DESCRIPTION
When I read some parts of the code today I came across a little inconsistency in the inline documentation.

See https://github.com/xmpp4r/xmpp4r/blob/master/lib/xmpp4r/client.rb#L34-43

``` ruby
    # host:: [String] Optional c2s host, will be extracted from jid if nil
    # use_ssl:: [Boolean] Optional. Use (old, deprecated) SSL when connecting.
    # return:: self
    def connect(host = nil, port = 5222)
```

There is no `use_ssl` parameter, but a `port` parameter here.
