### PR TITLE
fixed bug when non 'element' occured but 'text'

### DIFF
--- a/lib/xmpp4r/stream.rb
+++ b/lib/xmpp4r/stream.rb
@@ -203,6 +203,7 @@ module Jabber
           when 'features'
             stanza = element
             element.each { |e|
+              next unless e.class.to_s.split("::").last == "Element"
               if e.name == 'mechanisms' and e.namespace == 'urn:ietf:params:xml:ns:xmpp-sasl'
                 e.each_element('mechanism') { |mech|
                   @stream_mechanisms.push(mech.text)


### PR DESCRIPTION
Reach this when connecting to vines ruby xmpp server
