### PR TITLE
Add license to gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -139,6 +139,7 @@ begin
     s.summary = SUMMARY
     s.description = s.summary
     s.platform = Gem::Platform::RUBY
+    s.licenses = ["Ruby", "GPL"]
     s.require_path = 'lib'
     s.executables = []
     s.files = PKG_FILES


### PR DESCRIPTION
This is basically the same PR as #22. I just took his commit, and amended it to update the Rakefile instead of the gemspec directly.

[Ruby license](https://www.ruby-lang.org/en/about/license.txt)
