### PR TITLE
Don't send authzid when performing SASL PLAIN

### DIFF
--- a/lib/xmpp4r/sasl.rb
+++ b/lib/xmpp4r/sasl.rb
@@ -57,7 +57,7 @@ module Jabber
       ##
       # Authenticate via sending password in clear-text
       def auth(password)
-        auth_text = "#{@stream.jid.strip}\x00#{@stream.jid.node}\x00#{password}"
+        auth_text = "\x00#{@stream.jid.node}\x00#{password}"
         error = nil
         @stream.send(generate_auth('PLAIN', Base64::encode64(auth_text).gsub(/\s/, ''))) { |reply|
           if reply.name != 'success'


### PR DESCRIPTION
It's not allowed to use the authzid when it's no required according to
RFC 6120 6.3.8:

If the initiating entity does not wish to act on behalf of another
entity, it MUST NOT provide an authorization identity.

Fixes # 33
