### PR TITLE
delete full_name from gemspec

### DIFF
--- a/xmpp4r.gemspec
+++ b/xmpp4r.gemspec
@@ -233,7 +233,6 @@ Gem::Specification.new do |s|
  "tools/gen_requires.bash",
  "tools/xmpp4r-gemspec-test.rb",
  "xmpp4r.gemspec"]
-  s.full_name = "xmpp4r-0.5.7"
   s.has_rdoc = true
   s.homepage = "http://xmpp4r.github.io"
   s.name = "xmpp4r"


### PR DESCRIPTION
```
➜ bundle update xmpp4r
Updating git://github.com/xmpp4r/xmpp4r.git
There was a NoMethodError while loading xmpp4r.gemspec:
undefined method `full_name=' for #<Gem::Specification:0x3fecd1b09bec -> from
  /Users/username/.rvm/gems/ruby-2.0.0-p481@myapp/bundler/gems/xmpp4r-dae0f84d116c/xmpp4r.gemspec:236:in `block in <main>'
```
