### PR TITLE
gemspec: Drop removed properties; use HTTPS URL

### DIFF
--- a/xmpp4r.gemspec
+++ b/xmpp4r.gemspec
@@ -232,15 +232,13 @@ Gem::Specification.new do |s|
  "tools/gen_requires.bash",
  "tools/xmpp4r-gemspec-test.rb",
  "xmpp4r.gemspec"]
-  s.has_rdoc = true
-  s.homepage = "http://xmpp4r.github.io"
+  s.homepage = "https://xmpp4r.github.io"
   s.name = "xmpp4r"
   s.platform = "ruby"
   s.rdoc_options = ["--quiet", "--title", "XMPP/Jabber library for ruby", "--opname", "index.html", "--main", "lib/xmpp4r.rb", "--line-numbers", "--inline-source"]
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 1.8.7"
   s.required_rubygems_version = ">= 0"
-  s.rubyforge_project = "xmpp4r"
   s.rubygems_version = "2.4.1"
   s.specification_version = 4
   s.summary = "XMPP/Jabber library for ruby"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

In addition:

- drops the `has_rdoc` property, which does nothing.
- uses https:// for the `homepage` property

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436